### PR TITLE
remove EL6 from meta and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Requirements
 ------------
 
 Tested on CentOS 7.
-Untested but will likely work on CentOS 6 and equivalent RHEL versions.
+Will likely work on equivalent RHEL or RHEL derivatives.
 
 Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,8 +10,6 @@ galaxy_info:
   platforms:
   - name: EL
     versions:
-     - all
-     - 6
      - 7
 
   categories:


### PR DESCRIPTION
From issue #1 - a PR to remove EL6 from meta.
