### PR TITLE
Allow making changes to the base section in yum-cron and yum-cron-hourly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Role Variables
 You'll likely want to change the default `email_to` variable to an email address
 that you actually monitor.
 
+It's also possible to define special yum settings to for example exclude some packages from auto-updating:
+
+<pre>
+#hourly_base_options:
+# - "exclude=java*,kernel*"
+
+#daily_base_options: "{{ hourly_base_options }}"
+</pre>
 
 Example Playbook
 ----------------
@@ -40,3 +48,4 @@ Author Information
 ------------------
 
 Jeff Widman jeff@jeffwidman.com
+Johan Guldmyr jguldmyr@csc.fi

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,9 +15,12 @@ hourly_update_message: yes
 hourly_download_updates: yes
 hourly_apply_updates: yes
 hourly_random_sleep: 5
+#hourly_base_options:
+# - "exclude=java*,kernel*"
 
 daily_update_level: default
 daily_update_message: yes
 daily_download_updates: no
 daily_apply_updates: no
 daily_random_sleep: 60
+#daily_base_options: "{{ hourly_base_options }}"

--- a/templates/yum-cron-hourly.conf.j2
+++ b/templates/yum-cron-hourly.conf.j2
@@ -77,3 +77,9 @@ mdpolicy = group:main
 
 # Uncomment to auto-import new gpg keys (dangerous)
 # assumeyes = True
+
+{% if hourly_base_options is defined %}
+# Custom yum changes
+{% for option in hourly_base_options %}
+{{ option }}
+{% endfor %}

--- a/templates/yum-cron-hourly.conf.j2
+++ b/templates/yum-cron-hourly.conf.j2
@@ -77,9 +77,10 @@ mdpolicy = group:main
 
 # Uncomment to auto-import new gpg keys (dangerous)
 # assumeyes = True
-
 {% if hourly_base_options is defined %}
+
 # Custom yum changes
 {% for option in hourly_base_options %}
 {{ option }}
 {% endfor %}
+{% endif %}

--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -78,3 +78,9 @@ mdpolicy = group:main
 
 # Uncomment to auto-import new gpg keys (dangerous)
 # assumeyes = True
+
+{% if daily_base_options is defined %}
+# Custom yum changes
+{% for option in daily_base_options %}
+{{ option }}
+{% endfor %}

--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -78,9 +78,10 @@ mdpolicy = group:main
 
 # Uncomment to auto-import new gpg keys (dangerous)
 # assumeyes = True
-
 {% if daily_base_options is defined %}
+
 # Custom yum changes
 {% for option in daily_base_options %}
 {{ option }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
Hi!

My use for this is so I can add an exclude=java*

Some java apps don't like to have java upgraded underneath their feet.
