### PR TITLE
Yum clean cronjob

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,6 @@ daily_random_sleep: 60
 
 yum_cron_clean_what: "all"
 yum_cron_clean_enabled: False
-yum_cron_clean_state: "present"
 #yum_cron_clean_when is what comes after /etc/cron. so /etc/cron.daily/ /etc/cron.monthly
 yum_cron_clean_when: "daily"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,11 @@ daily_download_updates: no
 daily_apply_updates: no
 daily_random_sleep: 60
 #daily_base_options: "{{ hourly_base_options }}"
+
+yum_cron_clean_what: "all"
+yum_cron_clean_enabled: False
+yum_cron_clean_state: "present"
+#yum_cron_clean_when is what comes after /etc/cron. so /etc/cron.daily/ /etc/cron.monthly
+yum_cron_clean_when: "daily"
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,3 +26,7 @@
 - name: Ensures yum-cron service is running
   service: name=yum-cron state=started enabled=yes
   tags: yum-cron
+
+- name: Configure yum-cron-clean to run a yum clean regularly
+  template: src=yum_clean_cron.j2 dest=/etc/cron.{{ yum_cron_clean_when }}/yum_clean_cron mode=0755 state={{ yum_cron_clean_state }}
+      

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,5 +28,5 @@
   tags: yum-cron
 
 - name: Configure yum-cron-clean to run a yum clean regularly
-  template: src=yum_clean_cron.j2 dest=/etc/cron.{{ yum_cron_clean_when }}/yum_clean_cron mode=0755 state={{ yum_cron_clean_state }}
+  template: src=yum_clean_cron.j2 dest=/etc/cron.{{ yum_cron_clean_when }}/yum_clean_cron mode=0755
       

--- a/templates/yum_clean_cron.j2
+++ b/templates/yum_clean_cron.j2
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+/usr/bin/yum clean {{ yum_cron_clean_what }} >/dev/null
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t yum-cron-clean "ERROR: exited abnormally with [$EXITVALUE]"
+fi
+exit 0


### PR DESCRIPTION
Hello!

I've gotten quite tired of these:

<pre>
/etc/cron.hourly/0yum-hourly.cron:

Not using downloaded repomd.xml because it is older than what we have:
  Current   : Mon Jul 11 16:23:04 2016
  Downloaded: Mon Jul 11 12:23:09 2016
Not using downloaded repomd.xml because it is older than what we have:
  Current   : Mon Jul 11 16:22:25 2016
  Downloaded: Mon Jul 11 12:22:29 2016
</pre>


So here's a way to optionally (disabled by default) to install a cronjob which runs "yum clean all" (one can configure it to clean something else too).

I've only tested this cronjob for one day - but I hope this will solve the issue.
