### PR TITLE
Update variables to not potentially conflict with other ansible roles or playbooks.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,28 +3,28 @@
 
 # Defaults to Ansible inventory hostname.
 # If prefer to use system hostname, set to None.
-system_name: "{{ inventory_hostname }}"
-emit_via: email
-output_width: 80
-email_from: "yum_cron@{{ inventory_hostname }}"
-email_to: root
-email_host: localhost
-debug_level: -2
+yum_cron_system_name: "{{ inventory_hostname }}"
+yum_cron_emit_via: email
+yum_cron_output_width: 80
+yum_cron_email_from: "yum_cron@{{ inventory_hostname }}"
+yum_cron_email_to: root
+yum_cron_email_host: localhost
+yum_cron_debug_level: -2
 
-hourly_update_level: security
-hourly_update_message: yes
-hourly_download_updates: yes
-hourly_apply_updates: yes
-hourly_random_sleep: 5
-#hourly_base_options:
+yum_cron_hourly_update_level: security
+yum_cron_hourly_update_message: yes
+yum_cron_hourly_download_updates: yes
+yum_cron_hourly_apply_updates: yes
+yum_cron_hourly_random_sleep: 5
+#yum_cron_hourly_base_options:
 # - "exclude=java*,kernel*"
 
-daily_update_level: default
-daily_update_message: yes
-daily_download_updates: no
-daily_apply_updates: no
-daily_random_sleep: 60
-#daily_base_options: "{{ hourly_base_options }}"
+yum_cron_daily_update_level: default
+yum_cron_daily_update_message: yes
+yum_cron_daily_download_updates: no
+yum_cron_daily_apply_updates: no
+yum_cron_daily_random_sleep: 60
+#yum_cron_daily_base_options: "{{ hourly_base_options }}"
 
 yum_cron_clean_what: "all"
 yum_cron_clean_enabled: False

--- a/templates/yum-cron-hourly.conf.j2
+++ b/templates/yum-cron-hourly.conf.j2
@@ -6,54 +6,54 @@
 # minimal                            = yum --bugfix upgrade-minimal
 # minimal-security                   = yum --security upgrade-minimal
 # minimal-security-severity:Critical =  --sec-severity=Critical upgrade-minimal
-update_cmd = {{ hourly_update_level }}
+update_cmd = {{ yum_cron_hourly_update_level }}
 
 # Whether a message should emitted when updates are available.
-update_messages = {{ hourly_update_message }}
+update_messages = {{ yum_cron_hourly_update_message }}
 
 # Whether updates should be downloaded when they are available. Note
 # that updates_messages must also be yes for updates to be downloaded.
-download_updates = {{ hourly_download_updates }}
+download_updates = {{ yum_cron_hourly_download_updates }}
 
 # Whether updates should be applied when they are available.  Note
 # that both update_messages and download_updates must also be yes for
 # the update to be applied
-apply_updates = {{ hourly_apply_updates }}
+apply_updates = {{ yum_cron_hourly_apply_updates }}
 
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
 # minutes before running.  This is useful for e.g. staggering the
 # times that multiple systems will access update servers.  If
 # random_sleep is 0 or negative, the program will run immediately.
-random_sleep = {{ hourly_random_sleep }}
+random_sleep = {{ yum_cron_hourly_random_sleep }}
 
 
 [emitters]
 # Name to use for this system in messages that are emitted.  If
 # system_name is None, the hostname will be used.
-system_name = {{ system_name }}
+system_name = {{ yum_cron_system_name }}
 
 # How to send messages.  Valid options are stdio and email.  If
 # emit_via includes stdio, messages will be sent to stdout; this is useful
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
 # If emit_via is None or left blank, no messages will be sent.
-emit_via = {{ emit_via }}
+emit_via = {{ yum_cron_emit_via }}
 
 # The width, in characters, that messages that are emitted should be
 # formatted to.
-output_width = {{ output_width }}
+output_width = {{ yum_cron_output_width }}
 
 
 [email]
 # The address to send email messages from.
-email_from = {{ email_from }}
+email_from = {{ yum_cron_email_from }}
 
 # List of addresses to send messages to.
-email_to = {{ email_to }}
+email_to = {{ yum_cron_email_to }}
 
 # Name of the host to connect to to send email messages.
-email_host = {{ email_host }}
+email_host = {{ yum_cron_email_host }}
 
 
 [groups]
@@ -70,17 +70,17 @@ group_package_types = mandatory, default
 # -4: critical
 # -3: critical+errors
 # -2: critical+errors+warnings (default)
-debuglevel = {{ debug_level }}
+debuglevel = {{ yum_cron_debug_level }}
 
 # skip_broken = True
 mdpolicy = group:main
 
 # Uncomment to auto-import new gpg keys (dangerous)
 # assumeyes = True
-{% if hourly_base_options is defined %}
+{% if yum_cron_hourly_base_options is defined %}
 
 # Custom yum changes
-{% for option in hourly_base_options %}
+{% for option in yum_cron_hourly_base_options %}
 {{ option }}
 {% endfor %}
 {% endif %}

--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -6,18 +6,18 @@
 # minimal                            = yum --bugfix upgrade-minimal
 # minimal-security                   = yum --security upgrade-minimal
 # minimal-security-severity:Critical =  --sec-severity=Critical upgrade-minimal
-update_cmd = {{ daily_update_level }}
+update_cmd = {{ yum_cron_daily_update_level }}
 
 # Whether a message should be emitted when updates are available,
 # were downloaded, or applied.
-update_messages = {{ daily_update_message }}
+update_messages = {{ yum_cron_daily_update_message }}
 
 # Whether updates should be downloaded when they are available.
-download_updates = {{ daily_download_updates }}
+download_updates = {{ yum_cron_daily_download_updates }}
 
 # Whether updates should be applied when they are available.  Note
 # that download_updates must also be yes for the update to be applied.
-apply_updates = {{ daily_apply_updates }}
+apply_updates = {{ yum_cron_daily_apply_updates }}
 
 # Maximum amout of time to randomly sleep, in minutes.  The program
 # will sleep for a random amount of time between 0 and random_sleep
@@ -25,13 +25,13 @@ apply_updates = {{ daily_apply_updates }}
 # times that multiple systems will access update servers.  If
 # random_sleep is 0 or negative, the program will run immediately.
 # 6*60 = 360
-random_sleep = {{ daily_random_sleep }}
+random_sleep = {{ yum_cron_daily_random_sleep }}
 
 
 [emitters]
 # Name to use for this system in messages that are emitted.  If
 # system_name is None, the hostname will be used.
-system_name = {{ system_name }}
+system_name = {{ yum_cron_system_name }}
 
 # How to send messages.  Valid options are stdio and email.  If
 # emit_via includes stdio, messages will be sent to stdout; this is useful
@@ -42,18 +42,18 @@ emit_via = {{ emit_via }}
 
 # The width, in characters, that messages that are emitted should be
 # formatted to.
-output_width = {{ output_width }}
+output_width = {{ yum_cron_output_width }}
 
 
 [email]
 # The address to send email messages from.
-email_from = {{ email_from }}
+email_from = {{ yum_cron_email_from }}
 
 # List of addresses to send messages to.
-email_to = {{ email_to }}
+email_to = {{ yum_cron_email_to }}
 
 # Name of the host to connect to to send email messages.
-email_host = {{ email_host }}
+email_host = {{ yum_cron_email_host }}
 
 
 [groups]
@@ -71,7 +71,7 @@ group_package_types = mandatory, default
 # -4: critical
 # -3: critical+errors
 # -2: critical+errors+warnings (default)
-debuglevel = {{ debug_level }}
+debuglevel = {{ yum_cron_debug_level }}
 
 # skip_broken = True
 mdpolicy = group:main
@@ -81,7 +81,7 @@ mdpolicy = group:main
 {% if daily_base_options is defined %}
 
 # Custom yum changes
-{% for option in daily_base_options %}
+{% for option in yum_cron_daily_base_options %}
 {{ option }}
 {% endfor %}
 {% endif %}

--- a/templates/yum-cron.conf.j2
+++ b/templates/yum-cron.conf.j2
@@ -38,7 +38,7 @@ system_name = {{ yum_cron_system_name }}
 # to have cron send the messages.  If emit_via includes email, this
 # program will send email itself according to the configured options.
 # If emit_via is None or left blank, no messages will be sent.
-emit_via = {{ emit_via }}
+emit_via = {{ yum_cron_emit_via }}
 
 # The width, in characters, that messages that are emitted should be
 # formatted to.


### PR DESCRIPTION
As per the title, this is so that the variable names in this role are not able to conflict with other roles or playbooks by introducing a prefix to the variable names used.